### PR TITLE
Return mutable versions instead of immutable versions.

### DIFF
--- a/Lib/UICKeyChainStore.h
+++ b/Lib/UICKeyChainStore.h
@@ -24,16 +24,16 @@
 - (instancetype)initWithService:(NSString *)service;
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup;
 
-+ (NSString *)stringForKey:(NSString *)key;
-+ (NSString *)stringForKey:(NSString *)key service:(NSString *)service;
-+ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
++ (NSMutableString *)stringForKey:(NSString *)key;
++ (NSMutableString *)stringForKey:(NSString *)key service:(NSString *)service;
++ (NSMutableString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 
-+ (NSData *)dataForKey:(NSString *)key;
-+ (NSData *)dataForKey:(NSString *)key service:(NSString *)service;
-+ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
++ (NSMutableData *)dataForKey:(NSString *)key;
++ (NSMutableData *)dataForKey:(NSString *)key service:(NSString *)service;
++ (NSMutableData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;

--- a/Lib/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore.m
@@ -77,21 +77,21 @@ static NSString *_defaultService;
 
 #pragma mark -
 
-+ (NSString *)stringForKey:(NSString *)key
++ (NSMutableString *)stringForKey:(NSString *)key
 {
     return [self stringForKey:key service:[self defaultService] accessGroup:nil];
 }
 
-+ (NSString *)stringForKey:(NSString *)key service:(NSString *)service
++ (NSMutableString *)stringForKey:(NSString *)key service:(NSString *)service
 {
     return [self stringForKey:key service:service accessGroup:nil];
 }
 
-+ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
++ (NSMutableString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
-    NSData *data = [self dataForKey:key service:service accessGroup:accessGroup];
+    NSMutableData *data = [self dataForKey:key service:service accessGroup:accessGroup];
     if (data) {
-        return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        return [[NSMutableString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
     
     return nil;
@@ -115,17 +115,17 @@ static NSString *_defaultService;
 
 #pragma mark -
 
-+ (NSData *)dataForKey:(NSString *)key
++ (NSMutableData *)dataForKey:(NSString *)key
 {
     return [self dataForKey:key service:[self defaultService] accessGroup:nil];
 }
 
-+ (NSData *)dataForKey:(NSString *)key service:(NSString *)service
++ (NSMutableData *)dataForKey:(NSString *)key service:(NSString *)service
 {
     return [self dataForKey:key service:service accessGroup:nil];
 }
 
-+ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
++ (NSMutableData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     if (!key) {
         return nil;
@@ -153,10 +153,7 @@ static NSString *_defaultService;
         return nil;
     }
     
-    NSData *ret = [NSData dataWithData:(__bridge NSData *)data];
-    if (data) {
-        CFRelease(data);
-    }
+    NSMutableData *ret = (__bridge_transfer NSMutableData *)data;
     
     return ret;
 }


### PR DESCRIPTION
Changing return types from immutable to mutable versions.  This gives consumers control/ownership over the data buffers used.

I was pulling data out of the keychain and not scrubbing it when finished and that creates an attack vulnerability from a security perspective (an audit flagged this).  When the NSData was dealloc'd the underlying memory still contained the data.  In order for my concern to be met I needed UIKCS to return me mutable versions so I could do what I needed to do.