### PR TITLE
I made changes to UIKeyChainStore.h & UIKeyChainStore.m inorder to be ab...

### DIFF
--- a/Lib/UICKeyChainStore.h
+++ b/Lib/UICKeyChainStore.h
@@ -26,6 +26,18 @@ typedef NS_ENUM(NSInteger, UICKeyChainStoreErrorCode) {
 + (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service;
 + (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup;
 
+/*
+ For those who want to use this in swift, I prefixed the methods above with get for use in swift because the 3 class methods above where not made available when trying to use them with swift
+    Instead of
+        let store=UICKeyChainStore.keyChainStore() //This is not available in swift
+    You call
+        let store:UICKeyChainStore=UICKeyChainStore.getKeyChainStore()
+*/
+
++ (UICKeyChainStore *)getKeyChainStore;
++ (UICKeyChainStore *)getKeyChainStoreWithService:(NSString *)service;
++ (UICKeyChainStore *)getKeyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup;
+
 - (instancetype)init;
 - (instancetype)initWithService:(NSString *)service;
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup;

--- a/Lib/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore.m
@@ -50,6 +50,21 @@ static NSString *_defaultService;
     return [[self alloc] initWithService:service accessGroup:accessGroup];
 }
 
+
+/*
+ For those who want to use this in swift, I prefixed the methods above with get for use in swift because the 3 class methods above where not made available when trying to use them with swift
+ */
++ (UICKeyChainStore *)getKeyChainStore{
+    return [self keyChainStore];
+}
++ (UICKeyChainStore *)getKeyChainStoreWithService:(NSString *)service{
+    return [self keyChainStoreWithService:service];
+}
++ (UICKeyChainStore *)getKeyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup{
+    return [self keyChainStoreWithService:service accessGroup:accessGroup];
+}
+
+
 - (instancetype)init
 {
     return [self initWithService:[self.class defaultService] accessGroup:nil];


### PR DESCRIPTION
I wanted to use the lib with swift but couldnt access the objective c class method in swift. I just created some ample functions. Since class methods class  like
```swift
  UICKeyChainStore.keyChainStoreWithService()
```
 is not accessible in swift. I created getKeyChainStoreWithService class method instead to call keyChainStoreWithService underneath. So you simply use.
```
 UICKeyChainStore.getKeyChainStoreWithService() 
```
 in swift. Let me know if you have any other workaround instead of this.