### PR TITLE
Allow accessibility of items to be specified

### DIFF
--- a/Lib/UICKeyChainItem.h
+++ b/Lib/UICKeyChainItem.h
@@ -1,0 +1,18 @@
+//
+//  UICKeyChainItem.h
+//  
+//
+//  Created by Bobby Vandiver on 1/3/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface UICKeyChainItem : NSObject
+
+@property NSData *data;
+@property CFTypeRef accessibility;
+
+- (instancetype)initWithData:(NSData *)data accessibility:(CFTypeRef)accessibility;
+
+@end

--- a/Lib/UICKeyChainItem.m
+++ b/Lib/UICKeyChainItem.m
@@ -1,0 +1,22 @@
+//
+//  UICKeyChainItem.m
+//  
+//
+//  Created by Bobby Vandiver on 1/3/15.
+//
+//
+
+#import "UICKeyChainItem.h"
+
+@implementation UICKeyChainItem
+
+- (instancetype)initWithData:(NSData *)data accessibility:(CFTypeRef)accessibility {
+    self = [super init];
+    if (self) {
+        self.data = data;
+        self.accessibility = accessibility;
+    }
+    return self;
+}
+
+@end

--- a/Lib/UICKeyChainStore.h
+++ b/Lib/UICKeyChainStore.h
@@ -18,71 +18,129 @@ typedef NS_ENUM(NSInteger, UICKeyChainStoreErrorCode) {
 
 @property (nonatomic, readonly) NSString *service;
 @property (nonatomic, readonly) NSString *accessGroup;
+@property (nonatomic, readonly) CFTypeRef accessibility;
 
 + (NSString *)defaultService;
 + (void)setDefaultService:(NSString *)defaultService;
 
++ (CFTypeRef)defaultAccessibility;
++ (void)setDefaultAccessibility:(CFTypeRef)defaultAccessibility;
+
 + (UICKeyChainStore *)keyChainStore;
 + (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service;
++ (UICKeyChainStore *)keyChainStoreWithAccessibility:(CFTypeRef)accessibility;
++ (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessibility:(CFTypeRef)accessibility;
 + (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup;
++ (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
 
 - (instancetype)init;
 - (instancetype)initWithService:(NSString *)service;
+- (instancetype)initWithAccessibility:(CFTypeRef)accessibility;
+- (instancetype)initWithService:(NSString *)service accessibility:(CFTypeRef)accessibility;
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup;
+- (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
 
 + (NSString *)stringForKey:(NSString *)key;
 + (NSString *)stringForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
++ (NSString *)stringForKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
++ (NSString *)stringForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service;
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key error:(NSError * __autoreleasing *)error;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 + (NSData *)dataForKey:(NSString *)key;
 + (NSData *)dataForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
++ (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
++ (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service;
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key error:(NSError * __autoreleasing *)error;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 - (void)setString:(NSString *)string forKey:(NSString *)key;
 - (BOOL)setString:(NSString *)string forKey:(NSString *)key error:(NSError * __autoreleasing *)error;
+- (void)setString:(NSString *)string forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+- (BOOL)setString:(NSString *)string forKey:(NSString *)key accessbility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 - (NSString *)stringForKey:(NSString *)key;
 - (NSString *)stringForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
+- (NSString *)stringForKey:(NSString *)key accessbility:(CFTypeRef)accessibility;
+- (NSString *)stringForKey:(NSString *)key accessbility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 - (void)setData:(NSData *)data forKey:(NSString *)key;
 - (BOOL)setData:(NSData *)data forKey:(NSString *)key error:(NSError * __autoreleasing *)error;
+- (void)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+- (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 - (NSData *)dataForKey:(NSString *)key;
 - (NSData *)dataForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
+- (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+- (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 + (BOOL)removeItemForKey:(NSString *)key;
 + (BOOL)removeItemForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
++ (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
++ (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service;
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)removeAllItems;
 + (BOOL)removeAllItemsWithError:(NSError * __autoreleasing *)error;
++ (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility;
++ (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)removeAllItemsForService:(NSString *)service;
 + (BOOL)removeAllItemsForService:(NSString *)service error:(NSError * __autoreleasing *)error;
++ (BOOL)removeAllItemsForService:(NSString *)service accessibility:(CFTypeRef)accessibility;
++ (BOOL)removeAllItemsForService:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 + (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup;
 + (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError * __autoreleasing *)error;
++ (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility;
++ (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 - (void)removeItemForKey:(NSString *)key;
 - (BOOL)removeItemForKey:(NSString *)key error:(NSError * __autoreleasing *)error;
+- (void)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+- (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 - (void)removeAllItems;
 - (BOOL)removeAllItemsWithError:(NSError * __autoreleasing *)error;
+- (void)removeAllItemsWithAccessibility:(CFTypeRef)accessibility;
+- (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 
 - (void)synchronize;
 - (BOOL)synchronizeWithError:(NSError *__autoreleasing *)error;

--- a/Lib/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore.m
@@ -7,9 +7,11 @@
 //
 
 #import "UICKeyChainStore.h"
+#import "UICKeyChainItem.h"
 
 NSString * const UICKeyChainStoreErrorDomain = @"com.kishikawakatsumi.uickeychainstore";
 static NSString *_defaultService;
+static CFTypeRef _defaultAccessibility;
 
 @interface UICKeyChainStore () {
     NSMutableDictionary *itemsToUpdate;
@@ -33,6 +35,19 @@ static NSString *_defaultService;
     _defaultService = defaultService;
 }
 
++ (CFTypeRef)defaultAccessibility
+{
+    if (!_defaultAccessibility) {
+        _defaultAccessibility = kSecAttrAccessibleAfterFirstUnlock;
+    }
+    return _defaultAccessibility;
+}
+
++ (void)setDefaultAccessibility:(CFTypeRef)defaultAccessibility
+{
+    _defaultAccessibility = defaultAccessibility;
+}
+
 #pragma mark -
 
 + (UICKeyChainStore *)keyChainStore
@@ -45,9 +60,24 @@ static NSString *_defaultService;
     return [[self alloc] initWithService:service];
 }
 
++ (UICKeyChainStore *)keyChainStoreWithAccessibility:(CFTypeRef)accessibility
+{
+    return [[self alloc] initWithAccessibility:accessibility];
+}
+
++ (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [[self alloc] initWithService:service accessibility:accessibility];
+}
+
 + (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [[self alloc] initWithService:service accessGroup:accessGroup];
+}
+
++ (UICKeyChainStore *)keyChainStoreWithService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [[self alloc] initWithService:service accessGroup:accessGroup accessibility:accessibility];
 }
 
 - (instancetype)init
@@ -60,7 +90,22 @@ static NSString *_defaultService;
     return [self initWithService:service accessGroup:nil];
 }
 
+- (instancetype)initWithAccessibility:(CFTypeRef)accessibility
+{
+    return [self initWithService:[self.class defaultService] accessibility:accessibility];
+}
+
+- (instancetype)initWithService:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self initWithService:service accessGroup:nil accessibility:accessibility];
+}
+
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup
+{
+    return [self initWithService:service accessGroup:accessGroup accessibility:[self.class defaultAccessibility]];
+}
+
+- (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
 {
     self = [super init];
     if (self) {
@@ -69,6 +114,7 @@ static NSString *_defaultService;
         }
         _service = [service copy];
         _accessGroup = [accessGroup copy];
+        _accessibility = accessibility;
         
         itemsToUpdate = [[NSMutableDictionary alloc] init];
     }
@@ -88,6 +134,16 @@ static NSString *_defaultService;
     return [self stringForKey:key service:nil error:error];
 }
 
++ (NSString *)stringForKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self stringForKey:key accessibility:accessibility error:nil];
+}
+
++ (NSString *)stringForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self stringForKey:key service:nil accessibility:accessibility error:error];
+}
+
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service
 {
     return [self stringForKey:key service:service error:nil];
@@ -98,6 +154,16 @@ static NSString *_defaultService;
     return [self stringForKey:key service:service accessGroup:nil error:error];
 }
 
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self stringForKey:key service:service accessibility:accessibility error:nil];
+}
+
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self stringForKey:key service:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self stringForKey:key service:service accessGroup:accessGroup error:nil];
@@ -105,7 +171,17 @@ static NSString *_defaultService;
 
 + (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
 {
-    NSData *data = [self dataForKey:key service:service accessGroup:accessGroup error:error];
+    return [self stringForKey:key service:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self stringForKey:key service:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (NSString *)stringForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    NSData *data = [self dataForKey:key service:service accessGroup:accessGroup accessibility:accessibility error:error];
     if (data) {
         return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
@@ -123,6 +199,16 @@ static NSString *_defaultService;
     return [self setString:value forKey:key service:nil error:error];
 }
 
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self setString:value forKey:key accessibility:accessibility error:nil];
+}
+
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self setString:value forKey:key service:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service
 {
     return [self setString:value forKey:key service:service error:nil];
@@ -133,6 +219,16 @@ static NSString *_defaultService;
     return [self setString:value forKey:key service:service accessGroup:nil error:error];
 }
 
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self setString:value forKey:key service:service accessibility:accessibility error:nil];
+}
+
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self setString:value forKey:key service:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self setString:value forKey:key service:service accessGroup:accessGroup error:nil];
@@ -140,8 +236,18 @@ static NSString *_defaultService;
 
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
 {
+    return [self setString:value forKey:key service:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self setString:value forKey:key service:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (BOOL)setString:(NSString *)value forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
+{
     NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
-    return [self setData:data forKey:key service:service accessGroup:accessGroup error:error];
+    return [self setData:data forKey:key service:service accessGroup:accessGroup accessibility:accessibility error:error];
 }
 
 #pragma mark -
@@ -156,6 +262,16 @@ static NSString *_defaultService;
     return [self dataForKey:key service:nil error:error];
 }
 
++ (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self dataForKey:key accessibility:accessibility error:nil];
+}
+
++ (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{  
+    return [self dataForKey:key service:nil accessibility:accessibility error:error];
+}
+
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service
 {
     return [self dataForKey:key service:service error:nil];
@@ -166,12 +282,32 @@ static NSString *_defaultService;
     return [self dataForKey:key service:service accessGroup:nil error:error];
 }
 
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self dataForKey:key service:service accessibility:accessibility error:nil];
+}
+
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self dataForKey:key service:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self dataForKey:key service:service accessGroup:accessGroup error:nil];
 }
 
 + (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
+{
+    return [self dataForKey:key service:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self dataForKey:key service:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (NSData *)dataForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
 {
     if (!key) {
         if (error) {
@@ -181,6 +317,9 @@ static NSString *_defaultService;
     }
     if (!service) {
         service = [self defaultService];
+    }
+    if (!accessibility) {
+        accessibility = [self defaultAccessibility];
     }
     
     NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
@@ -194,6 +333,10 @@ static NSString *_defaultService;
     if (accessGroup) {
         [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     }
+#endif
+    
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
+    [query setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
 #endif
     
     CFTypeRef data = nil;
@@ -225,6 +368,16 @@ static NSString *_defaultService;
     return [self setData:data forKey:key service:nil error:error];
 }
 
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self setData:data forKey:key accessibility:accessibility error:nil];
+}
+
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self setData:data forKey:key service:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service
 {
     return [self setData:data forKey:key service:service error:nil];
@@ -235,12 +388,32 @@ static NSString *_defaultService;
     return [self setData:data forKey:key service:service accessGroup:nil error:error];
 }
 
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self setData:data forKey:key service:service accessibility:accessibility error:nil];
+}
+
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self setData:data forKey:key service:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self setData:data forKey:key service:service accessGroup:accessGroup error:nil];
 }
 
 + (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
+{
+    return [self setData:data forKey:key service:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self setData:data forKey:key service:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (BOOL)setData:(NSData *)data forKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error;
 {
     if (!key) {
         if (error) {
@@ -251,12 +424,19 @@ static NSString *_defaultService;
     if (!service) {
         service = [self defaultService];
     }
+    if (!accessibility) {
+        accessibility = [self defaultAccessibility];
+    }
     
     NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
     [query setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
     [query setObject:service forKey:(__bridge id)kSecAttrService];
     [query setObject:key forKey:(__bridge id)kSecAttrGeneric];
     [query setObject:key forKey:(__bridge id)kSecAttrAccount];
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
+    [query setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
+#endif
+
 #if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
     if (accessGroup) {
         [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
@@ -277,7 +457,7 @@ static NSString *_defaultService;
                 return NO;
             }
         } else {
-            [self removeItemForKey:key service:service accessGroup:accessGroup];
+            [self removeItemForKey:key service:service accessGroup:accessGroup accessibility:accessibility];
         }
     } else if (status == errSecItemNotFound) {
         if (!data) {
@@ -289,7 +469,7 @@ static NSString *_defaultService;
         [attributes setObject:key forKey:(__bridge id)kSecAttrGeneric];
         [attributes setObject:key forKey:(__bridge id)kSecAttrAccount];
 #if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
-        [attributes setObject:(__bridge id)kSecAttrAccessibleAfterFirstUnlock forKey:(__bridge id)kSecAttrAccessible];
+        [attributes setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
 #endif
         [attributes setObject:data forKey:(__bridge id)kSecValueData];
 #if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
@@ -322,9 +502,20 @@ static NSString *_defaultService;
     [self setData:[string dataUsingEncoding:NSUTF8StringEncoding] forKey:key error:nil];
 }
 
+- (void)setString:(NSString *)string forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    [self setData:[string dataUsingEncoding:NSUTF8StringEncoding] forKey:key accessibility:accessibility];
+}
+
 - (BOOL)setString:(NSString *)string forKey:(NSString *)key error:(NSError *__autoreleasing *)error
 {
     [self setData:[string dataUsingEncoding:NSUTF8StringEncoding] forKey:key error:error];
+    return error == nil;
+}
+
+- (BOOL)setString:(NSString *)string forKey:(NSString *)key accessbility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    [self setData:[string dataUsingEncoding:NSUTF8StringEncoding] forKey:key accessibility:accessibility error:error];
     return error == nil;
 }
 
@@ -335,7 +526,17 @@ static NSString *_defaultService;
 
 - (NSString *)stringForKey:(id)key error:(NSError *__autoreleasing *)error
 {
-    NSData *data = [self dataForKey:key error:error];
+    return [self stringForKey:key accessbility:self.accessibility error:error];
+}
+
+- (NSString *)stringForKey:(NSString *)key accessbility:(CFTypeRef)accessibility
+{
+    return [self stringForKey:key accessbility:accessibility error:nil];
+}
+
+- (NSString *)stringForKey:(NSString *)key accessbility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    NSData *data = [self dataForKey:key accessibility:accessibility error:error];
     if (data) {
         return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
@@ -350,7 +551,18 @@ static NSString *_defaultService;
     [self setData:data forKey:key error:nil];
 }
 
+- (void)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    [self setData:data forKey:key accessibility:accessibility error:nil];
+}
+
 - (BOOL)setData:(NSData *)data forKey:(NSString *)key error:(NSError *__autoreleasing *)error
+{
+    [self setData:data forKey:key accessibility:self.accessibility error:error];
+    return error == nil;
+}
+
+- (BOOL)setData:(NSData *)data forKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
 {
     if (!key) {
         if (error) {
@@ -361,7 +573,8 @@ static NSString *_defaultService;
     if (!data) {
         [self removeItemForKey:key error:error];
     } else {
-        [itemsToUpdate setObject:data forKey:key];
+        UICKeyChainItem *item = [[UICKeyChainItem alloc] initWithData:data accessibility:accessibility];
+        [itemsToUpdate setObject:item forKey:key];
     }
     return error == nil;
 }
@@ -373,9 +586,21 @@ static NSString *_defaultService;
 
 - (NSData *)dataForKey:(NSString *)key error:(NSError *__autoreleasing *)error
 {
-    NSData *data = [itemsToUpdate objectForKey:key];
+    return [self dataForKey:key accessibility:self.accessibility error:error];
+}
+
+- (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self dataForKey:key accessibility:accessibility error:nil];
+}
+
+- (NSData *)dataForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+
+{
+    UICKeyChainItem *item = [itemsToUpdate objectForKey:key];
+    NSData *data = item.data;
     if (!data) {
-        data = [self.class dataForKey:key service:self.service accessGroup:self.accessGroup error:error];
+        data = [self.class dataForKey:key service:self.service accessGroup:self.accessGroup accessibility:accessibility error:error];
     }
     
     return data;
@@ -393,6 +618,16 @@ static NSString *_defaultService;
     return [self removeItemForKey:key service:nil error:error];
 }
 
++ (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self removeItemForKey:key accessibility:accessibility error:nil];
+}
+
++ (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self removeItemForKey:key service:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service
 {
     return [self removeItemForKey:key service:service error:nil];
@@ -403,12 +638,32 @@ static NSString *_defaultService;
     return [self removeItemForKey:key service:service accessGroup:nil error:error];
 }
 
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self removeItemForKey:key service:service accessibility:accessibility error:nil];
+}
+
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self removeItemForKey:key service:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self removeItemForKey:key service:service accessGroup:accessGroup error:nil];
 }
 
 + (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
+{
+    return [self removeItemForKey:key service:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self removeItemForKey:key service:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (BOOL)removeItemForKey:(NSString *)key service:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
 {
     if (!key) {
         if (error) {
@@ -418,6 +673,9 @@ static NSString *_defaultService;
     }
     if (!service) {
         service = [self defaultService];
+    }
+    if (!accessibility) {
+        accessibility = [self defaultAccessibility];
     }
     
     NSMutableDictionary *itemToDelete = [[NSMutableDictionary alloc] init];
@@ -429,6 +687,10 @@ static NSString *_defaultService;
     if (accessGroup) {
         [itemToDelete setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     }
+#endif
+
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
+    [itemToDelete setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
 #endif
     
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)itemToDelete);
@@ -442,10 +704,13 @@ static NSString *_defaultService;
     return YES;
 }
 
-+ (NSArray *)itemsForService:(NSString *)service accessGroup:(NSString *)accessGroup
++ (NSArray *)itemsForService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
 {
     if (!service) {
         service = [self defaultService];
+    }
+    if (!accessibility) {
+        accessibility = [self defaultAccessibility];
     }
     
     NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
@@ -459,7 +724,11 @@ static NSString *_defaultService;
         [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     }
 #endif
-    
+
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
+    [query setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
+#endif
+
     CFArrayRef result = nil;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
     if (status == errSecSuccess || status == errSecItemNotFound) {
@@ -479,6 +748,16 @@ static NSString *_defaultService;
     return [self removeAllItemsForService:nil error:error];
 }
 
++ (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility
+{
+    return [self removeAllItemsWithAccessibility:accessibility error:nil];
+}
+
++ (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self removeAllItemsForService:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)removeAllItemsForService:(NSString *)service
 {
     return [self removeAllItemsForService:service error:nil];
@@ -489,6 +768,16 @@ static NSString *_defaultService;
     return [self removeAllItemsForService:service accessGroup:nil error:error];
 }
 
++ (BOOL)removeAllItemsForService:(NSString *)service accessibility:(CFTypeRef)accessibility
+{
+    return [self removeAllItemsForService:service accessibility:accessibility error:nil];
+}
+
++ (BOOL)removeAllItemsForService:(NSString *)service accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    return [self removeAllItemsForService:service accessGroup:nil accessibility:accessibility error:error];
+}
+
 + (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     return [self removeAllItemsForService:service accessGroup:accessGroup error:nil];
@@ -496,7 +785,17 @@ static NSString *_defaultService;
 
 + (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup error:(NSError *__autoreleasing *)error
 {
-    NSArray *items = [UICKeyChainStore itemsForService:service accessGroup:accessGroup];
+    return [self removeAllItemsForService:service accessGroup:accessGroup accessibility:nil error:error];
+}
+
++ (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility
+{
+    return [self removeAllItemsForService:service accessGroup:accessGroup accessibility:accessibility error:nil];
+}
+
++ (BOOL)removeAllItemsForService:(NSString *)service accessGroup:(NSString *)accessGroup accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    NSArray *items = [UICKeyChainStore itemsForService:service accessGroup:accessGroup accessibility:accessibility];
     for (NSDictionary *item in items) {
         NSMutableDictionary *itemToDelete = [[NSMutableDictionary alloc] initWithDictionary:item];
         [itemToDelete setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
@@ -517,19 +816,25 @@ static NSString *_defaultService;
 
 - (void)removeItemForKey:(NSString *)key
 {
-    if ([itemsToUpdate objectForKey:key]) {
-        [itemsToUpdate removeObjectForKey:key];
-    } else {
-        [self.class removeItemForKey:key service:self.service accessGroup:self.accessGroup error:nil];
-    }
+    [self removeItemForKey:key error:nil];
 }
 
 - (BOOL)removeItemForKey:(NSString *)key error:(NSError *__autoreleasing *)error
 {
+    return [self removeItemForKey:key accessibility:self.accessibility error:error];
+}
+
+- (void)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    [self removeItemForKey:key accessibility:accessibility error:nil];
+}
+
+- (BOOL)removeItemForKey:(NSString *)key accessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
     if ([itemsToUpdate objectForKey:key]) {
         [itemsToUpdate removeObjectForKey:key];
     } else {
-        [self.class removeItemForKey:key service:self.service accessGroup:self.accessGroup error:error];
+        [self.class removeItemForKey:key service:self.service accessGroup:self.accessGroup accessibility:accessibility error:error];
     }
     return error == nil;
 }
@@ -541,16 +846,28 @@ static NSString *_defaultService;
 
 - (BOOL)removeAllItemsWithError:(NSError *__autoreleasing *)error
 {
-    [itemsToUpdate removeAllObjects];
-    return [self.class removeAllItemsForService:self.service accessGroup:self.accessGroup error:error];
+    return [self removeAllItemsWithAccessibility:self.accessibility error:error];
 }
+
+- (void)removeAllItemsWithAccessibility:(CFTypeRef)accessibility
+{
+    [self removeAllItemsWithAccessibility:accessibility error:nil];
+}
+
+- (BOOL)removeAllItemsWithAccessibility:(CFTypeRef)accessibility error:(NSError * __autoreleasing *)error
+{
+    [itemsToUpdate removeAllObjects];
+    return [self.class removeAllItemsForService:self.service accessGroup:self.accessGroup accessibility:accessibility error:error];
+}
+
 
 #pragma mark -
 
 - (void)synchronize
 {
     for (NSString *key in itemsToUpdate) {
-        [self.class setData:[itemsToUpdate objectForKey:key] forKey:key service:self.service accessGroup:self.accessGroup error:nil];
+        UICKeyChainItem *item = [itemsToUpdate objectForKey:key];
+        [self.class setData:item.data forKey:key service:self.service accessGroup:self.accessGroup accessibility:item.accessibility error:nil];
     }
     
     [itemsToUpdate removeAllObjects];
@@ -559,7 +876,8 @@ static NSString *_defaultService;
 - (BOOL)synchronizeWithError:(NSError *__autoreleasing *)error
 {
     for (NSString *key in itemsToUpdate) {
-        [self.class setData:[itemsToUpdate objectForKey:key] forKey:key service:self.service accessGroup:self.accessGroup error:error];
+        UICKeyChainItem *item = [itemsToUpdate objectForKey:key];
+        [self.class setData:item.data forKey:key service:self.service accessGroup:self.accessGroup accessibility:item.accessibility error:error];
     }
     
     [itemsToUpdate removeAllObjects];
@@ -570,7 +888,7 @@ static NSString *_defaultService;
 
 - (NSString *)description
 {
-    NSArray *items = [UICKeyChainStore itemsForService:self.service accessGroup:self.accessGroup];
+    NSArray *items = [UICKeyChainStore itemsForService:self.service accessGroup:self.accessGroup accessibility:self.accessibility];
     NSMutableArray *list = [[NSMutableArray alloc] initWithCapacity:items.count];
     for (NSDictionary *attributes in items) {
         NSMutableDictionary *attrs = [[NSMutableDictionary alloc] init];

--- a/Mac/UICKeyChainStore.xcodeproj/project.pbxproj
+++ b/Mac/UICKeyChainStore.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		1472570E1957119900989F75 /* UICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1472570C1957119900989F75 /* UICKeyChainStore.h */; };
 		1472570F1957119900989F75 /* UICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 1472570D1957119900989F75 /* UICKeyChainStore.m */; };
 		14A86CCA1A1DD98A002F5380 /* UICKeyChainStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14A86CC91A1DD98A002F5380 /* UICKeyChainStoreTests.m */; };
+		713BCE011A58F676000F2D96 /* UICKeyChainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 713BCDFF1A58F676000F2D96 /* UICKeyChainItem.h */; };
+		713BCE021A58F676000F2D96 /* UICKeyChainItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 713BCE001A58F676000F2D96 /* UICKeyChainItem.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +43,8 @@
 		1472570C1957119900989F75 /* UICKeyChainStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UICKeyChainStore.h; sourceTree = "<group>"; };
 		1472570D1957119900989F75 /* UICKeyChainStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UICKeyChainStore.m; sourceTree = "<group>"; };
 		14A86CC91A1DD98A002F5380 /* UICKeyChainStoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UICKeyChainStoreTests.m; path = ../../Tests/UICKeyChainStoreTests.m; sourceTree = "<group>"; };
+		713BCDFF1A58F676000F2D96 /* UICKeyChainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UICKeyChainItem.h; sourceTree = "<group>"; };
+		713BCE001A58F676000F2D96 /* UICKeyChainItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UICKeyChainItem.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +146,8 @@
 		1472570B1957119900989F75 /* Lib */ = {
 			isa = PBXGroup;
 			children = (
+				713BCDFF1A58F676000F2D96 /* UICKeyChainItem.h */,
+				713BCE001A58F676000F2D96 /* UICKeyChainItem.m */,
 				1472570C1957119900989F75 /* UICKeyChainStore.h */,
 				1472570D1957119900989F75 /* UICKeyChainStore.m */,
 			);
@@ -157,6 +163,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1472570E1957119900989F75 /* UICKeyChainStore.h in Headers */,
+				713BCE011A58F676000F2D96 /* UICKeyChainItem.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,6 +248,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				713BCE021A58F676000F2D96 /* UICKeyChainItem.m in Sources */,
 				1472570F1957119900989F75 /* UICKeyChainStore.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/UICKeyChainStoreTests.m
+++ b/Tests/UICKeyChainStoreTests.m
@@ -44,6 +44,13 @@
     XCTAssertEqualObjects(serviceName, [UICKeyChainStore defaultService], @"specitfy default service name");
 }
 
+- (void)testSetDefaultAccessibility
+{
+    CFTypeRef accessibility = kSecAttrAccessibleAlwaysThisDeviceOnly;
+    [UICKeyChainStore setDefaultAccessibility:accessibility];
+    XCTAssertEqualObjects((__bridge id)accessibility, [UICKeyChainStore defaultAccessibility], "@specify default accessibility");
+}
+
 - (void)testInitializers
 {
     UICKeyChainStore *store = nil;
@@ -57,21 +64,36 @@
     NSString *serviceName = @"com.kishikawakatsumi.UICKeyChainStore";
     store = [UICKeyChainStore keyChainStoreWithService:serviceName];
     XCTAssertEqualObjects(store.service, serviceName, @"instantiate custom service named store");
+    
+    CFTypeRef accessibility = kSecAttrAccessibleAlwaysThisDeviceOnly;
+    store = [UICKeyChainStore keyChainStoreWithAccessibility:accessibility];
+    XCTAssertEqualObjects(store.accessibility, (__bridge id)accessibility, "@instantiate custom store with accessibility specified");
+    
+    store = [UICKeyChainStore keyChainStoreWithService:serviceName accessibility:accessibility];
+    XCTAssertEqualObjects(store.service, serviceName, "@instantiate custom service named store (with accessibility specified)");
+    XCTAssertEqualObjects(store.accessibility, (__bridge id)accessibility,
+                          @"instantiate custom store with accessibility specified (and named service");
 }
 
 - (void)testSetData
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
     NSData *usernameData = [username dataUsingEncoding:NSUTF8StringEncoding];
     NSData *passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *deviceData = [device dataUsingEncoding:NSUTF8StringEncoding];
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     [UICKeyChainStore setData:[username dataUsingEncoding:NSUTF8StringEncoding] forKey:usernameKey];
     [UICKeyChainStore setData:[password dataUsingEncoding:NSUTF8StringEncoding] forKey:passwordKey];
+    [UICKeyChainStore setData:deviceData forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([UICKeyChainStore dataForKey:usernameKey], usernameData, @"stored username");
     XCTAssertEqualObjects([UICKeyChainStore dataForKey:passwordKey], passwordData, @"stored password");
+    XCTAssertEqualObjects([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], deviceData, "@stored device");
     
     [UICKeyChainStore removeItemForKey:usernameKey service:[UICKeyChainStore defaultService]];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
@@ -80,16 +102,23 @@
     [UICKeyChainStore removeItemForKey:passwordKey service:[UICKeyChainStore defaultService]];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey], @"removed password");
+
+    [UICKeyChainStore removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility]);
 }
 
 - (void)testSetDataWithNoError
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
     NSData *usernameData = [username dataUsingEncoding:NSUTF8StringEncoding];
     NSData *passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *deviceData = [device dataUsingEncoding:NSUTF8StringEncoding];
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     NSError *error;
     
@@ -101,6 +130,11 @@
     [UICKeyChainStore setData:[password dataUsingEncoding:NSUTF8StringEncoding] forKey:passwordKey error:&error];
     XCTAssertNil(error, @"no error");
     XCTAssertEqualObjects([UICKeyChainStore dataForKey:passwordKey error:&error], passwordData, @"stored password");
+    XCTAssertNil(error, @"no error");
+
+    [UICKeyChainStore setData:deviceData forKey:deviceKey accessibility:accessibility error:&error];
+    XCTAssertNil(error, @"no error");
+    XCTAssertEqualObjects([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility error:&error], deviceData, "@stored device");
     XCTAssertNil(error, @"no error");
     
     [UICKeyChainStore removeItemForKey:usernameKey service:[UICKeyChainStore defaultService] error:&error];
@@ -116,26 +150,37 @@
     XCTAssertNil(error, @"no error");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey error:&error], @"removed password");
     XCTAssertNil(error, @"no error");
+
+    [UICKeyChainStore removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility]);
 }
 
 - (void)testSetNilData
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
     NSData *usernameData = [username dataUsingEncoding:NSUTF8StringEncoding];
     NSData *passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *deviceData = [device dataUsingEncoding:NSUTF8StringEncoding];
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     [UICKeyChainStore setData:nil forKey:usernameKey];
     [UICKeyChainStore setData:nil forKey:passwordKey];
+    [UICKeyChainStore setData:nil forKey:deviceKey accessibility:accessibility];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"no username");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey], @"no password");
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], @"no device");
     
     [UICKeyChainStore setData:[username dataUsingEncoding:NSUTF8StringEncoding] forKey:usernameKey];
     [UICKeyChainStore setData:[password dataUsingEncoding:NSUTF8StringEncoding] forKey:passwordKey];
+    [UICKeyChainStore setData:[device dataUsingEncoding:NSUTF8StringEncoding] forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([UICKeyChainStore dataForKey:usernameKey], usernameData, @"stored username");
     XCTAssertEqualObjects([UICKeyChainStore dataForKey:passwordKey], passwordData, @"stored password");
+    XCTAssertEqualObjects([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], deviceData, @"stored device");
     
     [UICKeyChainStore setData:nil forKey:usernameKey];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
@@ -144,6 +189,9 @@
     [UICKeyChainStore setData:nil forKey:passwordKey];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey], @"removed password");
+
+    [UICKeyChainStore setData:nil forKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], @"removed device");
     
     [UICKeyChainStore removeItemForKey:usernameKey];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
@@ -152,24 +200,34 @@
     [UICKeyChainStore removeItemForKey:passwordKey];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"removed username");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey], @"removed password");
+    
+    [UICKeyChainStore removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], @"removed device");
 }
 
 - (void)testSetUsernameAndPassword
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     UICKeyChainStore *store = [UICKeyChainStore keyChainStore];
     [store removeAllItems];
+    [store removeAllItemsWithAccessibility:accessibility];
     
     [UICKeyChainStore setString:username forKey:usernameKey];
     [UICKeyChainStore setString:password forKey:passwordKey];
+    [UICKeyChainStore setString:device forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility], device, @"stored device");
     XCTAssertEqualObjects([store stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility], device, @"stored device");
     
     [UICKeyChainStore removeItemForKey:usernameKey];
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey], @"removed username");
@@ -181,36 +239,51 @@
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey], @"removed password");
     XCTAssertNil([store stringForKey:usernameKey], @"removed username");
     XCTAssertNil([store stringForKey:passwordKey], @"removed password");
+
+    [UICKeyChainStore removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility], @"removed device");
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility], @"removed device");
 }
 
 - (void)testSetUsernameAndPasswordWithNoError
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     NSError *error;
     
     UICKeyChainStore *store = [UICKeyChainStore keyChainStore];
     [store removeAllItemsWithError:&error];
     XCTAssertNil(error, @"no error");
+    [store removeAllItemsWithAccessibility:accessibility error:&error];
+    XCTAssertNil(error, @"no error");
     
     [UICKeyChainStore setString:username forKey:usernameKey error:&error];
     XCTAssertNil(error, @"no error");
     [UICKeyChainStore setString:password forKey:passwordKey error:&error];
+    XCTAssertNil(error, @"no error");
+    [UICKeyChainStore setString:device forKey:deviceKey accessibility:accessibility error:&error];
     XCTAssertNil(error, @"no error");
     
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:usernameKey error:&error], username, @"stored username");
     XCTAssertNil(error, @"no error");
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:passwordKey error:&error], password, @"stored password");
     XCTAssertNil(error, @"no error");
+    XCTAssertEqualObjects([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility error:&error], device, @"stored device");
+    XCTAssertNil(error, @"no error");
     
     XCTAssertEqualObjects([store stringForKey:usernameKey error:&error], username, @"stored username");
     XCTAssertNil(error, @"no error");
     XCTAssertEqualObjects([store stringForKey:passwordKey error:&error], password, @"stored password");
     XCTAssertNil(error, @"no error");
-    
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility error:&error], device, @"stored device");
+    XCTAssertNil(error, @"no error");
+
     [UICKeyChainStore removeItemForKey:usernameKey error:&error];
     XCTAssertNil(error, @"no error");
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey error:&error], @"removed username");
@@ -230,29 +303,45 @@
     XCTAssertNil(error, @"no error");
     XCTAssertNil([store stringForKey:passwordKey error:&error], @"removed password");
     XCTAssertNil(error, @"no error");
+
+    [UICKeyChainStore removeItemForKey:deviceKey accessibility:accessibility error:&error];
+    XCTAssertNil(error, @"no error");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility error:&error], @"removed device");
+    XCTAssertNil(error, @"no error");
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility error:&error], @"removed device");
+    XCTAssertNil(error, @"no error");
 }
 
 - (void)testSetNilUsernameAndNilPassword
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     
     UICKeyChainStore *store = [UICKeyChainStore keyChainStore];
     [store removeAllItems];
+    [store removeAllItemsWithAccessibility:accessibility];
     
     [UICKeyChainStore setString:nil forKey:usernameKey];
     [UICKeyChainStore setString:nil forKey:passwordKey];
+    [UICKeyChainStore setString:nil forKey:deviceKey accessibility:accessibility];
     XCTAssertNil([UICKeyChainStore dataForKey:usernameKey], @"no username");
     XCTAssertNil([UICKeyChainStore dataForKey:passwordKey], @"no password");
+    XCTAssertNil([UICKeyChainStore dataForKey:deviceKey accessibility:accessibility], @"no device");
     
     [UICKeyChainStore setString:username forKey:usernameKey];
     [UICKeyChainStore setString:password forKey:passwordKey];
+    [UICKeyChainStore setString:device forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility], device, @"stored device");
     XCTAssertEqualObjects([store stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility], device, @"stored device");
     
     [UICKeyChainStore setString:nil forKey:usernameKey];
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey], @"removed username");
@@ -264,33 +353,48 @@
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey], @"removed password");
     XCTAssertNil([store stringForKey:usernameKey], @"removed username");
     XCTAssertNil([store stringForKey:passwordKey], @"removed password");
+
+    [UICKeyChainStore setString:nil forKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey accessibility:accessibility], @"removed device");
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility], @"removed device");
 }
 
 - (void)testSynchronize1
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
-    
+    NSString *device = @"deviceID";
+   
     NSString *serviceName = @"com.example.UICKeyChainStore";
     [UICKeyChainStore removeAllItemsForService:serviceName];
+
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    [UICKeyChainStore removeAllItemsForService:serviceName accessibility:accessibility];
     
     UICKeyChainStore *store = [UICKeyChainStore keyChainStoreWithService:serviceName];
     [store removeAllItems];
+    [store removeAllItemsWithAccessibility:accessibility];
     
     [store setString:username forKey:usernameKey];
     [store setString:password forKey:passwordKey];
+    [store setString:device forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([store stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility], device, @"stored device");
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey service:serviceName], @"not synchronized yet");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"not synchronized yet");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"not synchronized yet");
     
     [store synchronize];
     XCTAssertEqualObjects([store stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility], device, @"stored device");
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:usernameKey service:serviceName], username, @"stored username");
     XCTAssertEqualObjects([UICKeyChainStore stringForKey:passwordKey service:serviceName], password, @"stored password");
+    XCTAssertEqualObjects([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], device, @"stored device");
     
     [store removeItemForKey:usernameKey];
     XCTAssertNil([store stringForKey:usernameKey], @"removed username");
@@ -301,44 +405,65 @@
     [store removeItemForKey:passwordKey];
     XCTAssertNil([store stringForKey:passwordKey], @"removed password");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"removed password");
+    
+    [store removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility], @"removed device");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"removed device");
 }
 
 - (void)testSynchronize2
 {
     NSString *usernameKey = @"username";
     NSString *passwordKey = @"password";
+    NSString *deviceKey = @"device";
     NSString *username = @"kishikawakatsumi";
     NSString *password = @"password1234";
+    NSString *device = @"deviceID";
     
     NSString *serviceName = @"com.example.UICKeyChainStore";
     [UICKeyChainStore removeAllItemsForService:serviceName];
     
+    CFTypeRef accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    [UICKeyChainStore removeAllItemsForService:serviceName accessibility:accessibility];
+    
     UICKeyChainStore *store = [UICKeyChainStore keyChainStoreWithService:serviceName];
     [store removeAllItems];
+    [store removeAllItemsWithAccessibility:accessibility];
     
     [store setString:username forKey:usernameKey];
     [store setString:password forKey:passwordKey];
+    [store setString:device forKey:deviceKey accessibility:accessibility];
     XCTAssertEqualObjects([store stringForKey:usernameKey], username, @"stored username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"stored password");
+    XCTAssertEqualObjects([store stringForKey:deviceKey accessbility:accessibility], device, @"stored device");
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey service:serviceName], @"not synchronized yet");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"not synchronized yet");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"not synchronized yet");
     
     [store removeItemForKey:usernameKey];
     XCTAssertNil([store stringForKey:usernameKey], @"removed username");
     XCTAssertEqualObjects([store stringForKey:passwordKey], password, @"left password");
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey service:serviceName], @"not synchronized yet");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"not synchronized yet");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"not synchronized yet");
     
     [store removeItemForKey:passwordKey];
     XCTAssertNil([store stringForKey:passwordKey], @"removed password");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"not synchronized yet");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"not synchronized yet");
+
+    [store removeItemForKey:deviceKey accessibility:accessibility];
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility], @"removed device");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"not synchronized yet");
     
     [store synchronize];
     
     XCTAssertNil([store stringForKey:usernameKey], @"removed username");
     XCTAssertNil([store stringForKey:passwordKey], @"removed password");
+    XCTAssertNil([store stringForKey:deviceKey accessbility:accessibility], @"removed device");
     XCTAssertNil([UICKeyChainStore stringForKey:usernameKey service:serviceName], @"removed username");
     XCTAssertNil([UICKeyChainStore stringForKey:passwordKey service:serviceName], @"removed password");
+    XCTAssertNil([UICKeyChainStore stringForKey:deviceKey service:serviceName accessibility:accessibility], @"removed device");
 }
 
 - (void)testSynchronizeWithNoError

--- a/UICKeyChainStore.xcworkspace/contents.xcworkspacedata
+++ b/UICKeyChainStore.xcworkspace/contents.xcworkspacedata
@@ -10,6 +10,12 @@
       <FileRef
          location = "group:UICKeyChainStore.m">
       </FileRef>
+      <FileRef
+         location = "group:UICKeyChainItem.h">
+      </FileRef>
+      <FileRef
+         location = "group:UICKeyChainItem.m">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:iOS/UICKeyChainStore.xcodeproj">

--- a/iOS/UICKeyChainStore.xcodeproj/project.pbxproj
+++ b/iOS/UICKeyChainStore.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		147256BE19570FB600989F75 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 147256BC19570FB600989F75 /* InfoPlist.strings */; };
 		147257091957118800989F75 /* UICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 147257081957118800989F75 /* UICKeyChainStore.m */; };
 		14A86CC81A1DD980002F5380 /* UICKeyChainStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14A86CC71A1DD980002F5380 /* UICKeyChainStoreTests.m */; };
+		713BCDFE1A58F672000F2D96 /* UICKeyChainItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 713BCDFD1A58F672000F2D96 /* UICKeyChainItem.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,8 @@
 		147257071957118800989F75 /* UICKeyChainStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UICKeyChainStore.h; sourceTree = "<group>"; };
 		147257081957118800989F75 /* UICKeyChainStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UICKeyChainStore.m; sourceTree = "<group>"; };
 		14A86CC71A1DD980002F5380 /* UICKeyChainStoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UICKeyChainStoreTests.m; path = ../../Tests/UICKeyChainStoreTests.m; sourceTree = "<group>"; };
+		713BCDFC1A58F672000F2D96 /* UICKeyChainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UICKeyChainItem.h; sourceTree = "<group>"; };
+		713BCDFD1A58F672000F2D96 /* UICKeyChainItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UICKeyChainItem.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +154,8 @@
 		147257061957118800989F75 /* Lib */ = {
 			isa = PBXGroup;
 			children = (
+				713BCDFC1A58F672000F2D96 /* UICKeyChainItem.h */,
+				713BCDFD1A58F672000F2D96 /* UICKeyChainItem.m */,
 				147257071957118800989F75 /* UICKeyChainStore.h */,
 				147257081957118800989F75 /* UICKeyChainStore.m */,
 			);
@@ -271,6 +276,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				713BCDFE1A58F672000F2D96 /* UICKeyChainItem.m in Sources */,
 				147256AB19570FB600989F75 /* UICAppDelegate.m in Sources */,
 				147256A719570FB600989F75 /* main.m in Sources */,
 				147257091957118800989F75 /* UICKeyChainStore.m in Sources */,


### PR DESCRIPTION
This change set exposes a way to specify the accessibility of an item in the keychain when loading, storing or deleting the item for scenarios where `kSecAttrAccessibleAfterFirstUnlock` isn't the accessibility you need.