### PR TITLE
Fix static analysis errors .

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -784,7 +784,9 @@ static NSString *_defaultService;
     query[(__bridge __strong id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
     
     CFArrayRef result = nil;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query,(CFTypeRef *)&result);
+    CFDictionaryRef cfquery = (CFDictionaryRef)CFBridgingRetain(query);
+    OSStatus status = SecItemCopyMatching(cfquery,(CFTypeRef *)&result);
+    CFRelease(cfquery);
     
     if (status == errSecSuccess) {
         NSArray *items = [self prettify:itemClassObject items:(__bridge NSArray *)result];
@@ -822,7 +824,9 @@ static NSString *_defaultService;
 #endif
     
     CFArrayRef result = nil;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query,(CFTypeRef *)&result);
+    CFDictionaryRef cfquery = (CFDictionaryRef)CFBridgingRetain(query);
+    OSStatus status = SecItemCopyMatching(cfquery,(CFTypeRef *)&result);
+    CFRelease(cfquery);
     
     if (status == errSecSuccess) {
         return [self prettify:itemClassObject items:(__bridge NSArray *)result];


### PR DESCRIPTION
Used Facebook static code analyser [fbinfer.com], found and fixed the following errors:

MEMORY_LEAK
   memory dynamically allocated to query by call to alloc() at line 781, column 35 is not reachable after line 787, column 5

MEMORY_LEAK
   memory dynamically allocated to query by call to alloc() at line 816, column 35 is not reachable after line 825, column 5

Ref: http://stackoverflow.com/questions/16780202/secitemcopymatching-still-leak-on-osx-under-arc

Please enter the commit message for your changes. Lines starting