### PR TITLE
Moved deprecated method in category implementation

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -1371,7 +1371,7 @@ static NSString *_defaultService;
 
 @end
 
-@implementation UICKeyChainStore (Deprecated)
+@implementation UICKeyChainStore (Deprecation)
 
 - (void)synchronize
 {

--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -1071,19 +1071,6 @@ static NSString *_defaultService;
 
 #pragma mark -
 
-- (void)synchronize
-{
-    // Deprecated, calling this method is no longer required
-}
-
-- (BOOL)synchronizeWithError:(NSError *__autoreleasing *)error
-{
-    // Deprecated, calling this method is no longer required
-    return true;
-}
-
-#pragma mark -
-
 - (NSString *)description
 {
     NSArray *items = [self allItems];
@@ -1380,6 +1367,21 @@ static NSString *_defaultService;
     NSError *error = [NSError errorWithDomain:UICKeyChainStoreErrorDomain code:-99999 userInfo:@{NSLocalizedDescriptionKey: message}];
     NSLog(@"error: [%@] %@", @(error.code), error.localizedDescription);
     return error;
+}
+
+@end
+
+@implementation UICKeyChainStore (Deprecated)
+
+- (void)synchronize
+{
+    // Deprecated, calling this method is no longer required
+}
+
+- (BOOL)synchronizeWithError:(NSError *__autoreleasing *)error
+{
+    // Deprecated, calling this method is no longer required
+    return true;
 }
 
 @end


### PR DESCRIPTION
I've moved the implementation of the deprecated method `syncronize` e `synchronizeWithError:`from the main implementation to the `Deprecated`category implementation for avoiding the Implementing deprecated method warning