### PR TITLE
Fixing Analysis warning for potential memory leak

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -1176,6 +1176,7 @@ static NSString *_defaultService;
                 NSLog(@"error: [%@] %@", @(e.code), e.localizedDescription);
                 if (error) {
                     *error = e;
+                    CFRelease(accessControl);
                     return nil;
                 }
             }
@@ -1187,7 +1188,7 @@ static NSString *_defaultService;
                 }
                 return nil;
             }
-            attributes[(__bridge __strong id)kSecAttrAccessControl] = (__bridge id)accessControl;
+            attributes[(__bridge __strong id)kSecAttrAccessControl] = (__bridge_transfer id)accessControl;
         } else {
 #if TARGET_OS_IPHONE
             NSLog(@"%@", @"Unavailable 'Touch ID integration' on iOS versions prior to 8.0.");


### PR DESCRIPTION
Analysis of this code using Xcode 7 produces the following warning: 

These changes release accessControl on error or use a _bridge_transfer to transfer ownership to the attributes dictionary. 

```
/Users/glen.tregoning/Source/belieber/Pods/UICKeyChainStore/Lib/UICKeyChainStore/UICKeyChainStore.m:1173:49: warning: Potential leak of an object stored into 'accessControl'
            SecAccessControlRef accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibilityObject, (SecAccessControlCreateFlags)_authenticationPolicy, &securityError);
```