### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ item: {
 }
 ```
 
-### Convienient class methods
+### Convenient class methods
 
 Add items using default service name (=bundle identifer).
 


### PR DESCRIPTION
@kishikawakatsumi, I've corrected a typographical error in the documentation of the [UICKeyChainStore](https://github.com/kishikawakatsumi/UICKeyChainStore) project. Specifically, I've changed convienient to convenient. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.