### PR TITLE
Avoid TouchID in `-contains:`

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -360,9 +360,20 @@ static NSString *_defaultService;
 {
     NSMutableDictionary *query = [self query];
     query[(__bridge __strong id)kSecAttrAccount] = key;
-    
+#if TARGET_OS_IOS
+    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
+        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
+    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
+        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
+#endif
+    }
+#elif TARGET_OS_WATCH || TARGET_OS_TV
+    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#endif
+
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
-    return status == errSecSuccess;
+    return status == errSecSuccess || status == errSecInteractionNotAllowed;
 }
 
 #pragma mark -

--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -360,17 +360,7 @@ static NSString *_defaultService;
 {
     NSMutableDictionary *query = [self query];
     query[(__bridge __strong id)kSecAttrAccount] = key;
-#if TARGET_OS_IOS
-    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
-        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-#if  __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
-    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
-        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
-#endif
-    }
-#elif TARGET_OS_WATCH || TARGET_OS_TV
-    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-#endif
+    [self modifyQueryToSupressAuthenticationUI:query];
 
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
     return status == errSecSuccess || status == errSecInteractionNotAllowed;
@@ -537,18 +527,8 @@ static NSString *_defaultService;
     
     NSMutableDictionary *query = [self query];
     query[(__bridge __strong id)kSecAttrAccount] = key;
-#if TARGET_OS_IOS
-    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
-        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-#if  __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
-    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
-        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
-#endif
-    }
-#elif TARGET_OS_WATCH || TARGET_OS_TV
-    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-#endif
-    
+    [self modifyQueryToSupressAuthenticationUI:query];
+
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
     if (status == errSecSuccess || status == errSecInteractionNotAllowed) {
         query = [self query];
@@ -1153,6 +1133,21 @@ static NSString *_defaultService;
 #endif
     
     return query;
+}
+
+- (void)modifyQueryToSupressAuthenticationUI:(NSMutableDictionary *)query
+{
+#if TARGET_OS_IOS
+    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
+        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
+    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
+        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
+#endif
+    }
+#elif TARGET_OS_WATCH || TARGET_OS_TV
+    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#endif
 }
 
 - (NSMutableDictionary *)attributesWithKey:(NSString *)key value:(NSData *)value error:(NSError *__autoreleasing *)error


### PR DESCRIPTION
This change should allow to check if an TouchID-protected item exists silently. I'm not sure that it's the best approach though, it could also be exposed as a separate method.
