### PR TITLE
Enable Extension API only flag.

### DIFF
--- a/Lib/UICKeyChainStore.xcodeproj/project.pbxproj
+++ b/Lib/UICKeyChainStore.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 143BF2921C1CD598002BE6B3 /* UICKeyChainStore.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Debug;
 		};
@@ -380,6 +381,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 143BF2921C1CD598002BE6B3 /* UICKeyChainStore.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
To make it safe to use in extensions.