### PR TITLE
Add useAuthenticationUI property that can be failed without prompting…

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.h
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.h
@@ -121,6 +121,7 @@ typedef NS_ENUM(unsigned long, UICKeyChainStoreAuthenticationPolicy) {
 @property (nonatomic) UICKeyChainStoreAccessibility accessibility;
 @property (nonatomic, readonly) UICKeyChainStoreAuthenticationPolicy authenticationPolicy
 __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
+@property (nonatomic) BOOL useAuthenticationUI;
 
 @property (nonatomic) BOOL synchronizable;
 

--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -117,6 +117,7 @@ static NSString *_defaultService;
 - (void)commonInit
 {
     _accessibility = UICKeyChainStoreAccessibilityAfterFirstUnlock;
+    _useAuthenticationUI = YES;
 }
 
 #pragma mark -
@@ -360,9 +361,9 @@ static NSString *_defaultService;
 {
     NSMutableDictionary *query = [self query];
     query[(__bridge __strong id)kSecAttrAccount] = key;
-    
+
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
-    return status == errSecSuccess;
+    return status == errSecSuccess || status == errSecInteractionNotAllowed;
 }
 
 #pragma mark -
@@ -1140,6 +1141,20 @@ static NSString *_defaultService;
         }
     }
 #endif
+
+    if (!_useAuthenticationUI) {
+#if TARGET_OS_IOS
+        if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
+            query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
+        } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
+            query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
+#endif
+        }
+#elif TARGET_OS_WATCH || TARGET_OS_TV
+        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
+#endif
+    }
     
     return query;
 }


### PR DESCRIPTION
If set `useAuthenticationUI` to `YES`, `stringForKey:`, `dataForKey:` and `contains` fails silently if the items are protected by touch ID.