### PR TITLE
Fix Xcode 12 "deployment target" warning

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "UICKeyChainStore",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "UICKeyChainStore", targets: ["UICKeyChainStore"])


### PR DESCRIPTION
Although latest version ([v2.2.1](https://github.com/kishikawakatsumi/UICKeyChainStore/releases/tag/v2.2.1)) adds support to **Xcode 12**, I'm still getting this warning on it:

![UICKeyChainStore - Xcode 12 deployment target warning](https://user-images.githubusercontent.com/7226114/95765903-64337680-0caa-11eb-9401-7d9b870dc703.png)

This PR fixes such warning.