### PR TITLE
Fix SPM warning for Xcode 12 and 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "UICKeyChainStore",
-    platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
-    ],
     products: [
         .library(name: "UICKeyChainStore", targets: ["UICKeyChainStore"])
     ],


### PR DESCRIPTION
Unlike CocoaPods, SPM platforms only specify minimum supported deployment targets, and it's recommended to only specify platforms, if minimum supported deployment target is **higher** than Xcode's, which is not the case here.

When using package on Xcode 13, SPM shows a warning: 

`.../UICKeyChainStore/Package.swift The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.2.99.`

By removing platforms from Package.swift this warning will go away, since now Xcode is in charge of what platforms are supported, and automatically sets minimum deployment target for this package (which, on Xcode 13, is iOS 9).

This does not drop support for iOS 8, as support for iOS 8 was already dropped by Xcode 12, this change only removes a warning.

This PR is an alternative to #188, so you can have a choice in two different approaches. This one seems better to me, as you no longer need to manage deployment versions, and Xcode can just select whatever is supported at the moment.